### PR TITLE
Prune document data

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "merge": "node ./tools/merge.js",
+    "prune": "node ./tools/prune.js",
     "release": "node ./tools/release.js",
     "extract":"node ./tools/extract.js",
     "build":"node ./tools/build.js"

--- a/tools/lib/document.js
+++ b/tools/lib/document.js
@@ -1,6 +1,8 @@
 import fs from "fs-extra";
 import path from "path";
 
+import pruneDocument from './pruneDocument.js';
+
 /* A single document for adding to packs */
 export default class Document {
   constructor(filePath) {
@@ -39,6 +41,9 @@ export default class Document {
     };
     // Remove permission data
     this.#removeNestedKey("permission", item);
+
+    pruneDocument(item);
+
     return item;
   }
 

--- a/tools/lib/document.js
+++ b/tools/lib/document.js
@@ -5,8 +5,9 @@ import pruneDocument from './pruneDocument.js';
 
 /* A single document for adding to packs */
 export default class Document {
-  constructor(filePath) {
+  constructor(filePath, options) {
     this._filePath = filePath;
+    this._type = options.type;
   };
 
   get filePath() {
@@ -42,7 +43,7 @@ export default class Document {
     // Remove permission data
     this.#removeNestedKey("permission", item);
 
-    pruneDocument(item);
+    pruneDocument(item, { type: this._type });
 
     return item;
   }

--- a/tools/lib/document.js
+++ b/tools/lib/document.js
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import path from "path";
 
 /* A single document for adding to packs */
 export default class Document {
@@ -56,5 +57,3 @@ export default class Document {
     fs.writeJSONSync(filePath, data, {spaces: 2});
   };
 };
-
-

--- a/tools/lib/pack.js
+++ b/tools/lib/pack.js
@@ -10,8 +10,9 @@ import Document from "./document.js";
 
 /* A pack folder which can container multiple documents for addition */
 export default class Pack {
-  constructor(folderPath) {
+  constructor(folderPath, options) {
     this._folderPath = folderPath;
+    this._type = options.type;
   };
 
   get folderPath() {
@@ -32,7 +33,7 @@ export default class Pack {
       return fs.statSync(path.join(this.folderPath, file)).isFile();
     });
     inputFiles.map((file) => {
-      documents.push(new Document(path.join(this.folderPath, file)));
+      documents.push(new Document(path.join(this.folderPath, file), { type: this._type }));
     });
     return documents;
   };

--- a/tools/lib/pack.js
+++ b/tools/lib/pack.js
@@ -125,8 +125,9 @@ export default class Pack {
         originalData = matchingFiles[index].json;
         break;
     };
-    fs.writeJSONSync(filePath, document.json, {spaces: 2});
-    return {document: document, diffString: diffString(originalData, document.json)};
+    const diff = diffString(originalData, document.json);
+    if (diff) fs.writeJSONSync(filePath, document.json, {spaces: 2});
+    return {document: document, diffString: diff};
   };
 
   /* Update or Create the document */

--- a/tools/lib/packgroup.js
+++ b/tools/lib/packgroup.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "fs-extra";
 import path from "path";
 
 import Pack from "./pack.js";
@@ -17,13 +17,31 @@ export default class PackGroup {
     return this._packPath;
   };
 
+  get configuredPacks() {
+    const module = fs.readJSONSync('./module.json');
+    return module.packs.reduce((allPacks, pack) => {
+      allPacks[pack.name] = {
+        id: pack.name,
+        label: pack.label,
+        basename: path.win32.basename(pack.path, '.db'),
+        path: pack.path,
+        type: pack.type ?? pack.entity
+      };
+      return allPacks;
+    }, {});
+  }
+
   get packs() {
+    const knownPacks = this.configuredPacks;
+
     let packs = [];
     let folders = fs.readdirSync(this.packPath).filter((file) => {
       return fs.statSync(path.join(this.packPath, file)).isDirectory();
     });
     folders.map((folder) => {
-      packs.push(new Pack(path.join(this.packPath, folder)));
+      const known = knownPacks[folder] ?? Object.keys(knownPacks).find(p => p.basename === folder);
+      if (!known) console.warn("Could not match", folder, "to a pack in module.json for type information");
+      packs.push(new Pack(path.join(this.packPath, folder), { type: known?.type }));
     });
     return packs;
   };

--- a/tools/lib/pruneDocument.js
+++ b/tools/lib/pruneDocument.js
@@ -6,10 +6,24 @@
 function pruneCoreFoundry(json) {
   // Sorting position
   delete json.sort;
+
   // Active effects
   if (json.effects?.length === 0) delete json.effects;
+
   // Flags
-  if (json.flags && Object.keys(json.flags).length === 0) delete json.flags;
+  if (json.flags) {
+	  Object.entries(json.flags).forEach(([flag, value]) => {
+		  try {
+			  if (value == undefined || Object.keys(value).length === 0)
+				  delete json.flags[flag];
+		  }
+		  catch (err) {
+			  console.error(err, { value });
+		  }
+    });
+    if (Object.keys(json.flags).length === 0) delete json.flags;
+  }
+
   // Folder
   if (json.folder?.length === 0 || json.folder == null) delete json.folder;
   // User permissions
@@ -23,10 +37,14 @@ function pruneCorePF1(json) {
   // Boolean & Dictionary flags
   if (data.flags) {
     // Deal with both arrays and objects. Arrays are no longer supported, however.
-    if ((Array.isArray(data.flags.boolean) && data.flags.boolean.length == 0) || Object.keys(data.flags.boolean).length == 0)
-      delete data.flags.boolean;
-    if ((Array.isArray(data.flags.dictionary) && data.flags.dictionary.length == 0) || Object.keys(data.flags.dictionary).length == 0)
-      delete data.flags.dictionary;
+    if (data.flags.boolean) {
+      if ((Array.isArray(data.flags.boolean) && data.flags.boolean.length == 0) || Object.keys(data.flags.boolean).length == 0)
+        delete data.flags.boolean;
+    }
+    if (data.flags.dictionary) {
+      if ((Array.isArray(data.flags.dictionary) && data.flags.dictionary.length == 0) || Object.keys(data.flags.dictionary).length == 0)
+        delete data.flags.dictionary;
+    }
   }
 
   // Script calls
@@ -62,6 +80,21 @@ function pruneCorePF1(json) {
   // Changes
   if (data.changes?.length === 0)
     delete data.changes;
+
+  if (data.contextNotes?.length === 0)
+    delete data.contextNotes;
+
+  if (data.conditionals?.length === 0)
+    delete data.conditionals;
+
+  if (data.useCustomTag === false)
+    delete data.useCustomTag;
+
+  if (data.tag?.length === 0)
+    delete data.tag;
+
+  if (data.showInQuickbar === false)
+    delete data.showInQuickbar;
 
   // Change flags
   if (data.changeFlags) {
@@ -102,6 +135,9 @@ function pruneCorePF1(json) {
   // Sound effect
   if (data.soundEffect?.length === 0)
     delete data.soundEffect;
+
+  if (data.disabled === false)
+    delete data.disabled;
 }
 
 function pruneAction(json) {
@@ -113,10 +149,26 @@ function pruneAction(json) {
   if (data.effectNotes?.length === 0)
     delete data.effectNotes;
 
+  if (data.spellFailure !== undefined) {
+    // Spell failure is supposed to be a number
+    data.spellFailure = Number(data.spellFailure);
+
+    if (data.spellFailure === 0)
+      delete data.spellFailure;
+  }
+
   if (data.uses?.per === null) {
     delete data.uses.max;
     delete data.uses.maxFormula;
     delete data.uses.value;
+    delete data.uses.per;
+  }
+
+  if (data.target) {
+    if (data.target.value?.length === 0)
+      delete data.target.value;
+    if (Object.keys(data.target).length === 0)
+      delete data.target;
   }
 
   if (data.save) {
@@ -137,18 +189,24 @@ function pruneRange(json) {
 }
 
 // Handle attack related data if present.
-function pruneAttack(json) {
+function pruneAttackLike(json) {
   const data = json.data;
 
-  if (data.ability?.attack === null)
-    delete data.ability.attack;
-  if (data.ability?.damage === null)
-    delete data.ability.damage;
+  if (data.ability) {
+    if (data.ability.attack === null)
+      delete data.ability.attack;
+    if (data.ability.damage === null)
+      delete data.ability.damage;
+    if (data.ability.critRange === 20)
+      delete data.ability.critRange;
+  }
 
   if (data.attackName?.length === 0)
     delete data.attackName;
   if (data.attackBonus?.length === 0)
     delete data.attackBonus;
+  if (data.critConfirmBonus?.length === 0)
+    delete data.critConfirmBonus;
 
   if (data.attackParts?.length === 0)
     delete data.attackParts;
@@ -159,6 +217,22 @@ function pruneAttack(json) {
   if (data.attack) {
     if (data.attack.parts?.length === 0)
       delete data.attack.parts;
+  }
+
+  if (data.enh == null)
+    delete data.enh;
+
+  const fmAtk = data.formulaicAttacks;
+  if (fmAtk) {
+    if (fmAtk.count?.formula?.length === 0)
+      delete fmAtk.count;
+    if (fmAtk.bonus?.formula?.length === 0)
+      delete fmAtk.bonus;
+    if (fmAtk.label?.length === 0 || fmAtk.label === null)
+      delete fmAtk.label;
+
+    if (Object.keys(fmAtk).length === 0)
+      delete data.formulaicAttacks;
   }
 
   if (data.damage) {
@@ -200,13 +274,60 @@ function pruneTemplate(json) {
   }
 }
 
+function pruneFeature(json) {
+  const data = json.data;
+
+  if (data.abilityType === "none" || data.abilityType == null)
+    delete data.abilityType;
+}
+
+function pruneEquipment(json) {
+  const data = json.data;
+
+  if (data.equipmentType !== 'misc')
+    delete data.slot;
+}
+
+function pruneAttack(json) {
+  const data = json.data;
+
+  if (data.primaryAttack === true || data.attackType !== 'natural')
+    delete data.primaryAttack;
+}
+
+// Delete data that hasn't been used in a long long time by the system
+function deleteOldItemDataCruft(json) {
+  const data = json.data;
+
+  if (data.recharge)
+    delete data.recharge;
+  if (data.damageType)
+    delete data.damageType;
+  if (data.formula?.length === 0)
+    delete data.formula;
+  if (data.time)
+    delete data.time;
+}
 
 function pruneItem(json) {
   pruneCorePF1(json);
-  pruneAttack(json);
+  pruneAttackLike(json);
   pruneAction(json);
   pruneRange(json);
   pruneTemplate(json);
+
+  switch (json.type) {
+    case 'feat':
+      pruneFeature(json);
+      break;
+    case 'equipment':
+      pruneEquipment(json);
+      break;
+    case 'attack':
+      pruneAttack(json);
+  }
+
+  deleteOldItemDataCruft(json);
 }
 
 function pruneActor(json) {
@@ -217,14 +338,17 @@ function pruneActor(json) {
 export default function pruneDocument(json) {
   pruneCoreFoundry(json);
 
-  // WARNING: The tooling does not distinguish document types, so the following is a bit risky.
+  // WARNING: The tooling does not distinguish pack document types, so the following is a bit risky.
+  // Following checks are to minimize errors, but they're not foolproof.
 
   if (!json.data) return; // Journal or such
   if (!json.type) return; // Untyped documents
 
-  if (['character', 'npc'].includes(json.type))
+  if (['basic'].includes(json.type))
+    return;
+  else if (['character', 'npc'].includes(json.type))
     pruneActor(json);
-  else if (['buff', 'spell', 'loot', 'attack', 'weapon', 'feat', 'equipment', 'race', 'class'].includes(json.type))
+  else if (['buff', 'spell', 'loot', 'attack', 'weapon', 'consumable', 'feat', 'equipment', 'race', 'class', 'container'].includes(json.type))
     pruneItem(json);
   else
     console.warn("Unrecognized type:", json.type);

--- a/tools/lib/pruneDocument.js
+++ b/tools/lib/pruneDocument.js
@@ -1,0 +1,231 @@
+// Remove data that is not needed to be present.
+
+/**
+ * Remove unnecessary core Foundry data.
+ */
+function pruneCoreFoundry(json) {
+  // Sorting position
+  delete json.sort;
+  // Active effects
+  if (json.effects?.length === 0) delete json.effects;
+  // Flags
+  if (json.flags && Object.keys(json.flags).length === 0) delete json.flags;
+  // Folder
+  if (json.folder?.length === 0 || json.folder == null) delete json.folder;
+  // User permissions
+  delete json.permission;
+}
+
+// Handle PF1 data present in most item types
+function pruneCorePF1(json) {
+  const data = json.data;
+
+  // Boolean & Dictionary flags
+  if (data.flags) {
+    // Deal with both arrays and objects. Arrays are no longer supported, however.
+    if ((Array.isArray(data.flags.boolean) && data.flags.boolean.length == 0) || Object.keys(data.flags.boolean).length == 0)
+      delete data.flags.boolean;
+    if ((Array.isArray(data.flags.dictionary) && data.flags.dictionary.length == 0) || Object.keys(data.flags.dictionary).length == 0)
+      delete data.flags.dictionary;
+  }
+
+  // Script calls
+  if (data.scriptCalls?.length === 0) delete data.scriptCalls;
+
+  // Associations
+  if (data.associations) {
+    // Remove empty values
+    if (data.associations.classes)
+      data.associations.classes = data.associations.classes.filter(i => i?.length > 0);
+
+    // No class associations left
+    if (data.associations.classes?.length === 0)
+      delete data.associations.classes;
+
+    // No associations left at all
+    if (Object.keys(data.associations).length == 0)
+      delete data.associations;
+  }
+
+  // Links
+  if (data.links) {
+    if (data.links.charges?.length === 0)
+      delete data.links.charges;
+    if (data.links.children?.length === 0)
+      delete data.links.children;
+
+    // No links left
+    if (Object.keys(data.links).length === 0)
+      delete data.links;
+  }
+
+  // Changes
+  if (data.changes?.length === 0)
+    delete data.changes;
+
+  // Change flags
+  if (data.changeFlags) {
+    // Remove change flags that are not in effect
+    Object.entries(data.changeFlags).forEach(([flag, value]) => {
+      if (value === false) delete data.changeFlags[flag];
+    });
+
+    // No change flags left?
+    if (Object.keys(data.changeFlags).length === 0)
+      delete data.changeFlags;
+  }
+
+  // Clear empty armor proficiencies
+  if (data.armorProf) {
+    if (data.armorProf.custom?.length === 0)
+      delete data.armorProf.custom;
+    if (data.armorProf.value?.length === 0)
+      delete data.armorProf.value;
+    if (Object.keys(data.armorProf).length === 0)
+      delete data.armorProf;
+  }
+
+  // Clear empty weapon proficiencies
+  if (data.weaponProf) {
+    if (data.weaponProf.custom?.length === 0)
+      delete data.weaponProf.custom;
+    if (data.weaponProf.value?.length === 0)
+      delete data.weaponProf.value;
+    if (Object.keys(data.weaponProf).length === 0)
+      delete data.weaponProf;
+  }
+
+  // CR offset
+  if (data.crOffset?.length === 0)
+    delete data.crOffset;
+
+  // Sound effect
+  if (data.soundEffect?.length === 0)
+    delete data.soundEffect;
+}
+
+function pruneAction(json) {
+  const data = json.data;
+
+  if (data.actionType?.length === 0)
+    delete data.actionType;
+
+  if (data.effectNotes?.length === 0)
+    delete data.effectNotes;
+
+  if (data.uses?.per === null) {
+    delete data.uses.max;
+    delete data.uses.maxFormula;
+    delete data.uses.value;
+  }
+
+  if (data.save) {
+    if (data.save.description?.length === 0)
+      delete data.save.description;
+    if (data.save.dc === 0 && json.type !== 'spell')
+      delete data.save;
+  }
+
+}
+
+function pruneRange(json) {
+  const data = json.data;
+
+  const rangeType = data.range?.value;
+  if (rangeType?.length === 0 || rangeType === null)
+    delete data.range;
+}
+
+// Handle attack related data if present.
+function pruneAttack(json) {
+  const data = json.data;
+
+  if (data.ability?.attack === null)
+    delete data.ability.attack;
+  if (data.ability?.damage === null)
+    delete data.ability.damage;
+
+  if (data.attackName?.length === 0)
+    delete data.attackName;
+  if (data.attackBonus?.length === 0)
+    delete data.attackBonus;
+
+  if (data.attackParts?.length === 0)
+    delete data.attackParts;
+
+  if (data.attackNotes?.length === 0)
+    delete data.attackNotes;
+
+  if (data.attack) {
+    if (data.attack.parts?.length === 0)
+      delete data.attack.parts;
+  }
+
+  if (data.damage) {
+    if (data.damage.parts?.length === 0)
+      delete data.damage.parts;
+    if (data.damage.critParts?.length === 0)
+      delete data.damage.critParts;
+    if (data.damage.nonCritParts?.length === 0)
+      delete data.damage.nonCritParts;
+
+    if (Object.keys(data.damage).length === 0)
+      delete data.damage;
+  }
+
+  if (data.nonlethal === false)
+    delete data.nonlethal;
+}
+
+function pruneTemplate(json) {
+  const data = json.data;
+
+  const mtpl = data.measureTemplate;
+  if (mtpl) {
+    if (mtpl.customColor?.length === 0)
+      delete mtpl.customColor;
+    if (mtpl.customTexture?.length === 0)
+      delete mtpl.customTexture;
+    if (mtpl.size?.length === 0)
+      delete mtpl.size;
+    if (mtpl.type?.length === 0)
+      delete mtpl.type;
+    if (mtpl.overrideColor === false)
+      delete mtpl.overrideColor;
+    if (mtpl.overrideTexture === false)
+      delete mtpl.overrideTexture;
+
+    if (Object.keys(mtpl).length === 0)
+      delete data.measureTemplate;
+  }
+}
+
+
+function pruneItem(json) {
+  pruneCorePF1(json);
+  pruneAttack(json);
+  pruneAction(json);
+  pruneRange(json);
+  pruneTemplate(json);
+}
+
+function pruneActor(json) {
+  if (json.items?.length === 0)
+    delete json.items;
+}
+
+export default function pruneDocument(json) {
+  pruneCoreFoundry(json);
+
+  // WARNING: The tooling does not distinguish document types, so the following is a bit risky.
+
+  if (!json.data) return; // Journal or such
+  if (!json.type) return; // Untyped documents
+
+  if (['character', 'npc'].includes(json.type))
+    pruneActor(json);
+  else if (['buff', 'spell', 'loot', 'attack', 'weapon', 'feat', 'equipment', 'race', 'class'].includes(json.type))
+    pruneItem(json);
+  else
+    console.warn("Unrecognized type:", json.type);
+}

--- a/tools/lib/pruneDocument.js
+++ b/tools/lib/pruneDocument.js
@@ -12,14 +12,14 @@ function pruneCoreFoundry(json) {
 
   // Flags
   if (json.flags) {
-	  Object.entries(json.flags).forEach(([flag, value]) => {
-		  try {
-			  if (value == undefined || Object.keys(value).length === 0)
-				  delete json.flags[flag];
-		  }
-		  catch (err) {
-			  console.error(err, { value });
-		  }
+    Object.entries(json.flags).forEach(([flag, value]) => {
+      try {
+        if (value == undefined || Object.keys(value).length === 0)
+          delete json.flags[flag];
+      }
+      catch (err) {
+        console.error(err, { value });
+      }
     });
     if (Object.keys(json.flags).length === 0) delete json.flags;
   }
@@ -335,21 +335,19 @@ function pruneActor(json) {
     delete json.items;
 }
 
-export default function pruneDocument(json) {
-  pruneCoreFoundry(json);
+export default function pruneDocument(json, options) {
+  pruneCoreFoundry(json, options);
+
+  const type = options.type;
 
   // WARNING: The tooling does not distinguish pack document types, so the following is a bit risky.
   // Following checks are to minimize errors, but they're not foolproof.
 
-  if (!json.data) return; // Journal or such
-  if (!json.type) return; // Untyped documents
+  // Journals, untyped documents, etc. should not be processed farther.
+  if (!type || !json.data || !json.type) return;
 
-  if (['basic'].includes(json.type))
-    return;
-  else if (['character', 'npc'].includes(json.type))
-    pruneActor(json);
-  else if (['buff', 'spell', 'loot', 'attack', 'weapon', 'consumable', 'feat', 'equipment', 'race', 'class', 'container'].includes(json.type))
-    pruneItem(json);
-  else
-    console.warn("Unrecognized type:", json.type);
+  switch (type) {
+    case 'Actor': return pruneActor(json, options);
+    case 'Item': return pruneItem(json, options);
+  }
 }

--- a/tools/prune.js
+++ b/tools/prune.js
@@ -1,0 +1,21 @@
+// Prune stored .json files of unnecessary data to lighten the compendiums
+
+import PackGroup from "./lib/packgroup.js";
+import pruneDocument from './lib/pruneDocument.js';
+const srcPacks = new PackGroup("./src/packs");
+
+srcPacks.packs.forEach((pack) => {
+	console.log("Pruning pack:", pack.name);
+	const docs = pack.documents;
+	let lastReport = performance.now();
+	docs.forEach((doc, i) => {
+		// Report processing state every 5 seconds
+		const now = performance.now();
+		if ((now - lastReport) > 5_000) {
+			lastReport = now;
+			console.log(i, "/", docs.length, ":", doc.name);
+		}
+		const { diffString } = pack.updateDoc(doc);
+		if (diffString) console.log(doc.name, '\n', diffString);
+	});
+});

--- a/tools/prune.js
+++ b/tools/prune.js
@@ -4,18 +4,27 @@ import PackGroup from "./lib/packgroup.js";
 import pruneDocument from './lib/pruneDocument.js';
 const srcPacks = new PackGroup("./src/packs");
 
+const start = performance.now();
+let lastReport = start;
+
 srcPacks.packs.forEach((pack) => {
-	console.log("Pruning pack:", pack.name);
-	const docs = pack.documents;
-	let lastReport = performance.now();
-	docs.forEach((doc, i) => {
-		// Report processing state every 5 seconds
-		const now = performance.now();
-		if ((now - lastReport) > 5_000) {
-			lastReport = now;
-			console.log(i, "/", docs.length, ":", doc.name);
-		}
-		const { diffString } = pack.updateDoc(doc);
-		if (diffString) console.log(doc.name, '\n', diffString);
-	});
+  console.log("Pruning pack:", pack.name);
+  const docs = pack.documents;
+  docs.forEach((doc, i) => {
+    const startCurrent = performance.now();
+    // Do actual cleaning (updateDoc calls cleanup routines itself)
+    // TODO: Save document only if it has changed.
+    pack.updateDoc(doc);
+
+    // Report processing state every few seconds
+    const now = performance.now();
+    if ((now - lastReport) > 15_000) {
+      lastReport = now;
+      const currentDocTime = now - startCurrent;
+      console.log(i+1, "/", docs.length, ":", doc.name, `[${Math.round(currentDocTime)}ms]`);
+    }
+  });
 });
+
+const end = performance.now();
+console.log("All packs processed in", Math.round(end - start), "ms");


### PR DESCRIPTION
- Adds `npm run prune` command and greatly expands the built-in document cleaning functionality.
- This also fixes one of the existing getters in the toolset that was broken for some reason or another.
- This also adds somewhat hackish way to figure out type information for the packs (via module.json) which is only used to enhance the pruning functionality.
- The path.win32.basepath might look suspect, but it's as per Node documentation for consistent behaviour across platforms.

This removes relatively large quantities of data that is bad to be stored (e.g. per-user permissions), bunch of default data that doesn't need to exist (e.g. a lot of default values), and bunch of data that PF1 doesn't use and doesn't have migration to use.

Savings are roughly 2MB on the .db files, which is not as notable as I would like.

For this PR to matter, `npm run prune` needs to be run followed by `npm run build`.

If things work as intended, the prune command should not need to be re-run ever again unless the cleaning is extended, as it should autorun on per document basis when new data is added or updated.

As final word, since the savings are so small, I do not feel this PR is worth even half considering a new release. Just an update on the tooling.