### PR TITLE
Fix deprecated fields in module json

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
   "compatibleCoreVersion": "9",
   "minimumSystemVersion": "0.80.6",
   "flags": {},
-  "systems": ["pf1"],
+  "system": ["pf1"],
   "dependencies": [],
   "socket": false,
   "scripts": [],

--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
     "label": "PF-3.5e Content",
     "system": "pf1",
     "path": "packs/pf-35-content.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -37,7 +37,7 @@
     "label": "PF-Artifacts",
     "system": "pf1",
     "path": "packs/pf-artifacts.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -46,7 +46,7 @@
     "label": "PF-Buffs",
     "system": "pf1",
     "path": "packs/pf-buffs.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -55,7 +55,7 @@
     "label": "PF-Class Abilities",
     "system": "pf1",
     "path": "packs/pf-class-abilities.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -64,7 +64,7 @@
     "label": "PF-Animal Companions",
     "system": "pf1",
     "path": "packs/pf-companions.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "PF-Content",
     "private": false
   },
@@ -73,7 +73,7 @@
     "label": "PF-Animal Companion Features",
     "system": "pf1",
     "path": "packs/pf-companion-features.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -82,7 +82,7 @@
     "label": "PF-Deities",
     "system": "pf1",
     "path": "packs/pf-deities.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -91,7 +91,7 @@
     "label": "PF-Eidolon Forms",
     "system": "pf1",
     "path": "packs/pf-eidolon-forms.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "PF-Content",
     "private": false
   },
@@ -100,7 +100,7 @@
     "label": "PF-Eidolon Evolutions",
     "system": "pf1",
     "path": "packs/pf-eidolon-evolutions.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -109,7 +109,7 @@
     "label": "PF-Encounter Tables",
     "system": "pf1",
     "path": "packs/pf-encounter-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -118,7 +118,7 @@
     "label": "Elephant in the Room",
     "system": "pf1",
     "path": "packs/elephant-in-the-room.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -127,7 +127,7 @@
     "label": "PF-Familiars",
     "system": "pf1",
     "path": "packs/pf-familiars.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "PF-Content",
     "private": false
   },
@@ -136,7 +136,7 @@
     "label": "PF-Feats",
     "system": "pf1",
     "path": "packs/pf-feats.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -145,7 +145,7 @@
     "label": "GM Quick Reference",
     "system": "pf1",
     "path": "packs/gm-quick-reference.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -154,7 +154,7 @@
     "label": "PF-Goods and Services",
     "system": "pf1",
     "path": "packs/pf-goods-services.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -163,7 +163,7 @@
     "label": "Harrow Deck",
     "system": "pf1",
     "path": "packs/harrow-deck.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -172,7 +172,7 @@
     "label": "PF-Items",
     "system": "pf1",
     "path": "packs/pf-items.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -181,7 +181,7 @@
     "label": "PF-Magic Items",
     "system": "pf1",
     "path": "packs/pf-magic.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -190,7 +190,7 @@
     "label": "PF-Maladies",
     "system": "pf1",
     "path": "packs/pf-maladies.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -199,7 +199,7 @@
     "label": "PF-Merchants",
     "system": "pf1",
     "path": "packs/pf-merchants.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "PF-Content",
     "private": false
   },
@@ -208,7 +208,7 @@
     "label": "PF-Magic Item Tables",
     "system": "pf1",
     "path": "packs/pf-magic-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -217,7 +217,7 @@
     "label": "PF-Occult Rituals",
     "system": "pf1",
     "path": "packs/pf-occult-rituals.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -226,7 +226,7 @@
     "label": "PF-Racial Traits",
     "system": "pf1",
     "path": "packs/pf-racial-traits.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -235,7 +235,7 @@
     "label": "PF-Rules",
     "system": "pf1",
     "path": "packs/pf-rules.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -244,7 +244,7 @@
     "label": "PF-Special Qualities",
     "system": "pf1",
     "path": "packs/pf-special-qualities.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -253,7 +253,7 @@
     "label": "PF-Tables",
     "system": "pf1",
     "path": "packs/pf-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -262,7 +262,7 @@
     "label": "PF-Technology",
     "system": "pf1",
     "path": "packs/pf-technology.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -271,7 +271,7 @@
     "label": "PF-Traits",
     "system": "pf1",
     "path": "packs/pf-traits.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -280,7 +280,7 @@
     "label": "PF-Traps and Haunts",
     "system": "pf1",
     "path": "packs/pf-traps-and-haunts.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "pf1e-journals",
     "private": false
   },
@@ -289,7 +289,7 @@
     "label": "PF-Universal Monster Rules",
     "system": "pf1",
     "path": "packs/pf-universal-monster-rules.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },      
@@ -298,7 +298,7 @@
     "label": "PF-Wondrous",
     "system": "pf1",
     "path": "packs/pf-wondrous.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },  
@@ -307,7 +307,7 @@
     "label": "Kingdom Building Rules - GM",
     "system": "pf1",
     "path": "packs/kingdom-building-gm.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -316,7 +316,7 @@
     "label": "Kingdom Building Rules - Player",
     "system": "pf1",
     "path": "packs/kingdom-building-player.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -325,7 +325,7 @@
     "label": "Kingdom Building - Scenes",
     "system": "pf1",
     "path": "packs/kingdom-building-scenes.db",
-    "entity": "Scene",
+    "type": "Scene",
     "module": "PF-Content",
     "private": false
   },
@@ -334,7 +334,7 @@
     "label": "Kingdom Building - Buildings",
     "system": "pf1",
     "path": "packs/kingdom-building-buildings.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "PF-Content",
     "private": false
   },
@@ -343,7 +343,7 @@
     "label": "Kingdom Building - Tables",
     "system": "pf1",
     "path": "packs/kingdom-building-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   }]

--- a/pf-content lite module.json
+++ b/pf-content lite module.json
@@ -27,7 +27,7 @@
     "label": "PF-Buffs",
     "system": "pf1",
     "path": "packs/pf-buffs.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -36,7 +36,7 @@
     "label": "PF-Class Abilities",
     "system": "pf1",
     "path": "packs/pf-class-abilities.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -45,7 +45,7 @@
     "label": "PF-Encounter Tables",
     "system": "pf1",
     "path": "packs/pf-encounter-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -54,7 +54,7 @@
     "label": "PF-Feats",
     "system": "pf1",
     "path": "packs/pf-feats.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -63,7 +63,7 @@
     "label": "GM Quick Reference",
     "system": "pf1",
     "path": "packs/gm-quick-reference.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -72,7 +72,7 @@
     "label": "PF-Goods and Services",
     "system": "pf1",
     "path": "packs/pf-goods-services.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -81,7 +81,7 @@
     "label": "PF-Items",
     "system": "pf1",
     "path": "packs/pf-items.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -90,7 +90,7 @@
     "label": "PF-Magic Items",
     "system": "pf1",
     "path": "packs/pf-magic.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -99,7 +99,7 @@
     "label": "PF-Magic Item Tables",
     "system": "pf1",
     "path": "packs/pf-magic-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -108,7 +108,7 @@
     "label": "PF-Maladies",
     "system": "pf1",
     "path": "packs/pf-maladies.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -117,7 +117,7 @@
     "label": "PF-Racial Traits",
     "system": "pf1",
     "path": "packs/pf-racial-traits.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -126,7 +126,7 @@
     "label": "PF-Rules",
     "system": "pf1",
     "path": "packs/pf-rules.db",
-    "entity": "JournalEntry",
+    "type": "JournalEntry",
     "module": "PF-Content",
     "private": false
   },
@@ -135,7 +135,7 @@
     "label": "PF-Special Qualities",
     "system": "pf1",
     "path": "packs/pf-special-qualities.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },
@@ -144,7 +144,7 @@
     "label": "PF-Tables",
     "system": "pf1",
     "path": "packs/pf-tables.db",
-    "entity": "RollTable",
+    "type": "RollTable",
     "module": "PF-Content",
     "private": false
   },
@@ -153,7 +153,7 @@
     "label": "PF-Traits",
     "system": "pf1",
     "path": "packs/pf-traits.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   },
@@ -162,7 +162,7 @@
     "label": "PF-Traps and Haunts",
     "system": "pf1",
     "path": "packs/pf-traps-and-haunts.db",
-    "entity": "Actor",
+    "type": "Actor",
     "module": "pf1e-journals",
     "private": false
   },
@@ -171,7 +171,7 @@
     "label": "PF-Universal Monster Rules",
     "system": "pf1",
     "path": "packs/pf-universal-monster-rules.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "PF-Content",
     "private": false
   },      
@@ -180,7 +180,7 @@
     "label": "PF-Wondrous",
     "system": "pf1",
     "path": "packs/pf-wondrous.db",
-    "entity": "Item",
+    "type": "Item",
     "module": "pf-content",
     "private": false
   }]

--- a/pf-content lite module.json
+++ b/pf-content lite module.json
@@ -6,7 +6,7 @@
   "minimumCoreVersion": "0.8.8",
   "compatibleCoreVersion": "0.8.8",
   "flags": {},
-  "systems": ["pf1"],
+  "system": ["pf1"],
   "dependencies": [],
   "socket": false,
   "scripts": [],


### PR DESCRIPTION
This PR fixes two cases of deprecated fields in module.json (and pf-content lite module.json):

- "systems" in the root instead of "system"
- "entity" instead of "type" in the "packs" list

Both have been deprecated in V9 and will be removed with V10: https://gitlab.com/foundrynet/foundryvtt/-/issues/6666
